### PR TITLE
Pass NextVersionIdMarker to next list_object_versions call

### DIFF
--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -174,10 +174,7 @@ def do_restore():
     transfer = boto3.s3.transfer.S3Transfer(client)
     dest = args.dest
     last_obj = {}
-    objects = {}
     last_obj["Key"] = ""
-    objects["IsTruncated"] = True
-    objects["NextKeyMarker"] = ""
 
     if args.debug: boto3.set_stream_logger('botocore')
 
@@ -190,8 +187,8 @@ def do_restore():
     os.chdir(dest)
 
     # AWS gives us versions chunks of maximum 1000 element, cycling here to obtain more
-    while (objects["IsTruncated"] == True):
-        objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix, KeyMarker=objects["NextKeyMarker"])
+    objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix) # cannot pass VersionIdMarker on first call
+    while (True):
         if not "Versions" in objects:
             print("No versions matching criteria, exiting ...", file=sys.stderr)
             sys.exit(1)
@@ -215,6 +212,14 @@ def do_restore():
                 except Exception as ex:
                     print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex), file=sys.stderr)
                 del(futures[future])
+
+        if objects["IsTruncated"]:
+            # More objects to be got
+            objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix, \
+                KeyMarker=objects["NextKeyMarker"], VersionIdMarker=objects["NextVersionIdMarker"])
+        else:
+            break
+
 
 if __name__=='__main__':
     signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
Without this, if there are more than 1000 versions of a given key, the process will not advance to the next key.
