### PR TITLE
support restore to s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+test*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 build
 dist
-test*

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This is the repository for s3-pit-restore, a point in time restore tool
 for Amazon S3.
 
 The typical scenario in which you may need this tool is when you have
-enabled versioning on an S3 bucket and want to restore, some or all of
+enabled versioning on an S3 bucket and want to restore some or all of
 the files to a certain point in time, to local file system, same s3 bucket or different s3 bucket.
 
 Doing this with the web interface is time consuming: Amazon S3 web management
 gui doesn't offer a simple way to do that on a massive scale.
 
 With this tool you can easily restore a repository to a point in time
-with a simple command like this:-
+with a simple command like:
 
 	* To local file-system:-
 		`$ s3-pit-restore -b my-bucket -d restored-bucket-local -t "06-17-2016 23:59:50 +2"`
@@ -68,10 +68,9 @@ or clone the repository and launch:
 ## Command line options
 
 ```
-usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-p PREFIX]
-                      [-t TIMESTAMP] [-f FROM_TIMESTAMP] [-d DEST] [-e] [-v]
-                      [--dry-run] [--debug] [--test]
-                      [--max-workers MAX_WORKERS]
+usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST] [-p PREFIX]
+                      [-t TIMESTAMP] [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run]
+                      [--debug] [--test] [--max-workers MAX_WORKERS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -79,13 +78,13 @@ optional arguments:
                         s3 bucket to restore from
   -B DEST_BUCKET, --dest-bucket DEST_BUCKET
                         s3 bucket where recovering to
+  -d DEST, --dest DEST  path where recovering to on local or on s3
   -p PREFIX, --prefix PREFIX
                         s3 path to restore from
   -t TIMESTAMP, --timestamp TIMESTAMP
                         final point in time to restore at
   -f FROM_TIMESTAMP, --from-timestamp FROM_TIMESTAMP
                         starting point in time to restore from
-  -d DEST, --dest DEST  path where recovering to on local or on s3
   -e, --enable-glacier  enable recovering from glacier
   -v, --verbose         print verbose informations from s3 objects
   --dry-run             execute query without transferring files
@@ -99,11 +98,11 @@ optional arguments:
 
 s3-pit-restore comes with a testing suite. You can run it with:
 
-### Restore to local file-system test cases:-
+### Restore to local file-system test cases:
 	`$ ./s3-pit-restore -b my-bucket -d /tmp/ --test`
 
-### Restore to s3 bucket test cases:-
+### Restore to s3 bucket test cases:
 	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 --test` (make sure you have s3 bucket `restore-bucket-s3`)
 
-### Run all the test cases:-
+### Run all the test cases:
 	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 -d /tmp/ --test`

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@ This is the repository for s3-pit-restore, a point in time restore tool
 for Amazon S3.
 
 The typical scenario in which you may need this tool is when you have
-enabled versioning on an S3 bucket and want to restore some or all of
-the files to a certain point in time.
+enabled versioning on an S3 bucket and want to restore, some or all of
+the files to a certain point in time, to local file system, same s3 bucket or different s3 bucket.
 
 Doing this with the web interface is time consuming: Amazon S3 web management
 gui doesn't offer a simple way to do that on a massive scale.
 
 With this tool you can easily restore a repository to a point in time
-with a simple command like this:
+with a simple command like this:-
 
-`:~$ s3-pit-restore -b my-bucket -d my-restored-bucket -t "06-17-2016 23:59:50 +2"`
+	* To local file-system:-
+		`$ s3-pit-restore -b my-bucket -d restored-bucket-local -t "06-17-2016 23:59:50 +2"`
+	* To s3 bucket:-
+		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -t "06-17-2016 23:59:50 +2"`
 
 Choosing the correct time and date to restore at is simply a matter of getting
 that information clicking the *Versions: Show* button from the S3 web gui
@@ -23,48 +26,66 @@ and navigating through the, now appeared, versions timestamps.
 
 With pip install:
 
-`:~# pip3 install s3-pit-restore`
+`$ pip3 install s3-pit-restore`
 
 or clone the repository and launch:
 
-`:~# python3 setup.py install`
+`$ python3 setup.py install`
 
 ## Usage
 
 `s3-pit-restore` can do a lot of interesting things. The base one is restoring an entire bucket to a previous state:
 
-`:~# s3-pit-restore -b my-bucket -d my-restored-bucket -t "06-17-2016 23:59:50 +2"`
+### Restore to local file-system
 
-Another thing it can do is to restore a subfolder (*prefix*) of a bucket:
+	* Restore to local file-system directory `restored-bucket-local`
+		`$ s3-pit-restore -b my-bucket -d restored-bucket-local -t "06-17-2016 23:59:50 +2"`
 
-`:~# s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -t "06-17-2016 23:59:50 +2"`
+### Restore to s3 bucket
 
-You can also speedup the download if you have bandwidth using more parallel workers:
+	* Restore to same bucket:-
+		`$ s3-pit-restore -b my-bucket -B my-bucket -t "06-17-2016 23:59:50 +2"`
 
-`:~# s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -t "06-17-2016 23:59:50 +2" --max-workers 100`
+	* Restore to different bucket:-
+		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -t "06-17-2016 23:59:50 +2"`
 
-If want to restore a well defined time span, you can use a starting and ending timestamp (a month in this example):
+	* Restore to s3 bucket with custom virtual path [restored object(src_obj) will have key as `new-restored-path/src_obj["Key"]`]
+		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -d new-restored-path -t "06-17-2016 23:59:50 +2"`
 
-`:~# s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -f "05-01-2016 00:00:00 +2" -t "06-01-2016 00:00:00 +2"`
+### Other common options for both the cases
+
+(explained using `Restore to local file-system` case)
+
+	* Another thing it can do is to restore a subfolder (*prefix*) of a bucket:
+		`$ s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -t "06-17-2016 23:59:50 +2"`
+
+	* You can also speedup the download if you have bandwidth using more parallel workers:
+		`$ s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -t "06-17-2016 23:59:50 +2" --max-workers 100`
+
+	* If want to restore a well defined time span, you can use a starting and ending timestamp (a month in this example):
+		`$ s3-pit-restore -b my-bucket -d my-restored-subfolder -p mysubfolder -f "05-01-2016 00:00:00 +2" -t "06-01-2016 00:00:00 +2"`
 
 ## Command line options
 
 ```
-usage: s3-pit-restore [-h] -b BUCKET [-p PREFIX] [-t TIMESTAMP]
-                      [-f FROM_TIMESTAMP] -d DEST [-e] [-v] [--dry-run]
-                      [--debug] [--test] [--max-workers MAX_WORKERS]
+usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-p PREFIX]
+                      [-t TIMESTAMP] [-f FROM_TIMESTAMP] [-d DEST] [-e] [-v]
+                      [--dry-run] [--debug] [--test]
+                      [--max-workers MAX_WORKERS]
 
 optional arguments:
   -h, --help            show this help message and exit
   -b BUCKET, --bucket BUCKET
                         s3 bucket to restore from
+  -B DEST_BUCKET, --dest-bucket DEST_BUCKET
+                        s3 bucket where recovering to
   -p PREFIX, --prefix PREFIX
                         s3 path to restore from
   -t TIMESTAMP, --timestamp TIMESTAMP
                         final point in time to restore at
   -f FROM_TIMESTAMP, --from-timestamp FROM_TIMESTAMP
                         starting point in time to restore from
-  -d DEST, --dest DEST  path where recovering to
+  -d DEST, --dest DEST  path where recovering to on local or on s3
   -e, --enable-glacier  enable recovering from glacier
   -v, --verbose         print verbose informations from s3 objects
   --dry-run             execute query without transferring files
@@ -78,4 +99,11 @@ optional arguments:
 
 s3-pit-restore comes with a testing suite. You can run it with:
 
-`./s3-pit-restore -b my-bucket -d /tmp/ --test`
+### Restore to local file-system test cases:-
+	`$ ./s3-pit-restore -b my-bucket -d /tmp/ --test`
+
+### Restore to s3 bucket test cases:-
+	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 --test` (make sure you have s3 bucket `restore-bucket-s3`)
+
+### Run all the test cases:-
+	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 -d /tmp/ --test`

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ or clone the repository and launch:
 	* Restore to different bucket:-
 		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -t "06-17-2016 23:59:50 +2"`
 
-	* Restore to s3 bucket with custom virtual path [restored object(src_obj) will have key as `new-restored-path/src_obj["Key"]`]
-		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -d new-restored-path -t "06-17-2016 23:59:50 +2"`
+	* Restore to s3 bucket with custom virtual prefix [restored object(src_obj) will have key as `new-restored-path/src_obj["Key"]`]
+		`$ s3-pit-restore -b my-bucket -B restored-bucket-s3 -P new-restored-path -t "06-17-2016 23:59:50 +2"`
 
 ### Other common options for both the cases
 
@@ -68,9 +68,10 @@ or clone the repository and launch:
 ## Command line options
 
 ```
-usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST] [-p PREFIX]
-                      [-t TIMESTAMP] [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run]
-                      [--debug] [--test] [--max-workers MAX_WORKERS]
+usage: s3-pit-restore [-h] -b BUCKET [-B DEST_BUCKET] [-d DEST]
+                      [-P DEST_PREFIX] [-p PREFIX] [-t TIMESTAMP]
+                      [-f FROM_TIMESTAMP] [-e] [-v] [--dry-run] [--debug]
+                      [--test] [--max-workers MAX_WORKERS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -78,9 +79,11 @@ optional arguments:
                         s3 bucket to restore from
   -B DEST_BUCKET, --dest-bucket DEST_BUCKET
                         s3 bucket where recovering to
-  -d DEST, --dest DEST  path where recovering to on local or on s3
+  -d DEST, --dest DEST  path where recovering to on local
   -p PREFIX, --prefix PREFIX
                         s3 path to restore from
+  -P DEST_PREFIX, --dest-prefix DEST_PREFIX
+                        s3 path to restore to
   -t TIMESTAMP, --timestamp TIMESTAMP
                         final point in time to restore at
   -f FROM_TIMESTAMP, --from-timestamp FROM_TIMESTAMP
@@ -102,7 +105,7 @@ s3-pit-restore comes with a testing suite. You can run it with:
 	`$ ./s3-pit-restore -b my-bucket -d /tmp/ --test`
 
 ### Restore to s3 bucket test cases:
-	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 --test` (make sure you have s3 bucket `restore-bucket-s3`)
+	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 -P restore-path --test` (make sure you have s3 bucket `restore-bucket-s3`)
 
 ### Run all the test cases:
-	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 -d /tmp/ --test`
+	`$ ./s3-pit-restore -b my-bucket -B restore-bucket-s3 -d /tmp/ -P restore-path --test`

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -53,8 +53,8 @@ class TestS3PitRestore(unittest.TestCase):
 
     def download_restored_file(self, path):
         base_path = os.path.basename(os.path.normpath(path))
-        if args.dest:
-            base_path = os.path.join(args.dest, base_path)
+        if args.dest_prefix:
+            base_path = os.path.join(args.dest_prefix, base_path)
 
         s3 = boto3.resource('s3')
         paginator = s3.meta.client.get_paginator('list_objects_v2')
@@ -70,6 +70,9 @@ class TestS3PitRestore(unittest.TestCase):
     def check_tree(self, path, contents):
         if args.dest_bucket is not None:
             self.download_restored_file(path)
+            path = os.path.basename(os.path.normpath(path))
+            if args.dest_prefix:
+               path = os.path.join(args.dest_prefix, path)
         for i, content in enumerate(contents):
             folder_path = os.path.join(path, "folder%d" % i)
             os.makedirs(folder_path, exist_ok=True)
@@ -86,7 +89,7 @@ class TestS3PitRestore(unittest.TestCase):
         return True
 
     def upload_directory(self, resource, path, bucketname):
-        with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:                
+        with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:
             for root,dirs,files in os.walk(path):
                for f in files:
                   base_path = os.path.basename(os.path.normpath(path))
@@ -246,9 +249,9 @@ def download_file(obj):
     os.utime(obj["Key"],(unixtime, unixtime))
 
 def get_key(obj):
-    if not args.dest:
+    if not args.dest_prefix:
         return  obj["Key"]
-    return os.path.join(args.dest, obj["Key"])
+    return os.path.join(args.dest_prefix, obj["Key"])
 
 def s3_copy_object(obj):
     copy_source= {
@@ -310,8 +313,8 @@ def do_restore():
             version_date = obj["LastModified"]
 
             if version_date > pit_end_date or version_date < pit_start_date:
-                # Object was not updated during pit window
-                obj_needs_be_deleted[obj["Key"]] = obj
+                if pit_start_date == datetime.fromtimestamp(0, timezone.utc):
+                    obj_needs_be_deleted[obj["Key"]] = obj
                 continue
 
             while deletemarkers and (dmarker["Key"] < obj["Key"] or dmarker["LastModified"] > pit_end_date):
@@ -346,7 +349,7 @@ def do_restore():
                     print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex), file=sys.stderr)
                 del(futures[future])
     # delete objects which came in existence after pit_end_date only if the destination bucket is same as source bucket and restoring to same object key
-    if args.dest_bucket == args.bucket and not args.dest:
+    if args.dest_bucket == args.bucket and not args.dest_prefix:
         for key in obj_needs_be_deleted:
             handled_by_delete(obj_needs_be_deleted[key])
         for future in concurrent.futures.as_completed(futures):
@@ -364,8 +367,9 @@ if __name__=='__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--bucket', help='s3 bucket to restore from', required=True)
     parser.add_argument('-B', '--dest-bucket', help='s3 bucket where recovering to', required=False)
-    parser.add_argument('-d', '--dest', help='path where recovering to on local or on s3', default="")
+    parser.add_argument('-d', '--dest', help='path where recovering to on local', default="")
     parser.add_argument('-p', '--prefix', help='s3 path to restore from', default="")
+    parser.add_argument('-P', '--dest-prefix', help='s3 path to restore to', default="")
     parser.add_argument('-t', '--timestamp', help='final point in time to restore at')
     parser.add_argument('-f', '--from-timestamp', help='starting point in time to restore from')
     parser.add_argument('-e', '--enable-glacier', help='enable recovering from glacier', action='store_true')
@@ -385,8 +389,11 @@ if __name__=='__main__':
     else:
         runner = unittest.TextTestRunner()
         dest_bucket = args.dest_bucket
+        dest_prefix = args.dest_prefix
+
         #To run the test cases for local restore, Later we restore this
         args.dest_bucket = None
+        args.dest_prefix = None
         if args.dest:
             itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
             runner.run(itersuite)
@@ -396,4 +403,10 @@ if __name__=='__main__':
         if args.dest_bucket is not None:
             itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
             runner.run(itersuite)
+
+            # Restore back dest_prefix state
+            if dest_prefix:
+                args.dest_prefix = dest_prefix
+                itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
+                runner.run(itersuite)
     sys.exit(0)

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -57,13 +57,15 @@ class TestS3PitRestore(unittest.TestCase):
             base_path = os.path.join(args.dest, base_path)
 
         s3 = boto3.resource('s3')
-        objects_to_download = s3.meta.client.list_objects(Bucket=args.dest_bucket, Prefix=base_path)
+        paginator = s3.meta.client.get_paginator('list_objects_v2')
+        page_iterator = paginator.paginate(Bucket=args.dest_bucket, Prefix=base_path)
         with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:
-            for obj in objects_to_download.get('Contents', []):
-                key_path = os.path.dirname(obj["Key"])
-                if key_path and not os.path.exists(key_path):
-                        os.makedirs(key_path)
-                e.submit(s3.Bucket(args.dest_bucket).download_file(obj["Key"], obj["Key"]))
+            for page in page_iterator:
+               for obj in page.get('Contents', []):
+                  key_path = os.path.dirname(obj["Key"])
+                  if key_path and not os.path.exists(key_path):
+                      os.makedirs(key_path)
+                  e.submit(s3.Bucket(args.dest_bucket).download_file(obj["Key"], obj["Key"]))
 
     def check_tree(self, path, contents):
         if args.dest_bucket is not None:
@@ -86,19 +88,22 @@ class TestS3PitRestore(unittest.TestCase):
     def upload_directory(self, resource, path, bucketname):
         with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:                
             for root,dirs,files in os.walk(path):
-                for f in files:
-                    base_path = os.path.basename(os.path.normpath(path))
-                    local_path = os.path.join(root, f)
-                    relative_path = os.path.relpath(local_path, path)
-                    s3_path = os.path.join(base_path, relative_path)
-                    e.submit(resource.meta.client.upload_file, local_path, bucketname, s3_path)
+               for f in files:
+                  base_path = os.path.basename(os.path.normpath(path))
+                  local_path = os.path.join(root, f)
+                  relative_path = os.path.relpath(local_path, path)
+                  s3_path = os.path.join(base_path, relative_path)
+                  e.submit(resource.meta.client.upload_file, local_path, bucketname, s3_path)
 
     def delete_directory(self, resource, path):
         base_path = os.path.basename(os.path.normpath(path))
-        objects_to_delete = resource.meta.client.list_objects(Bucket=args.bucket, Prefix=base_path)
-        delete_keys = {'Objects' : []}
-        delete_keys['Objects'] = [{'Key' : k} for k in [obj['Key'] for obj in objects_to_delete.get('Contents', [])]]
-        resource.meta.client.delete_objects(Bucket=args.bucket, Delete=delete_keys)
+        paginator = resource.meta.client.get_paginator('list_objects_v2')
+        page_iterator = paginator.paginate(Bucket=args.bucket, Prefix=base_path)
+        with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:
+            for page in page_iterator:
+               delete_keys = {'Objects' : []}
+               delete_keys['Objects'] = [{'Key' : k} for k in [obj['Key'] for obj in page.get('Contents', [])]]
+               e.submit(resource.meta.client.delete_objects(Bucket=args.bucket, Delete=delete_keys))
 
     def remove_tree(self, path):
         if os.path.exists(path) and os.path.isdir(path):
@@ -113,9 +118,8 @@ class TestS3PitRestore(unittest.TestCase):
         print("enabled!")
 
     def test_restore(self):
-        #AWS gives us versions chunks of maximum 1000 element, cycling here to obtain more
-        contents_before = [ str(uuid.uuid4()) for n in range(999) ]
-        contents_after =  [ str(uuid.uuid4()) for n in range(999) ]
+        contents_before = [ str(uuid.uuid4()) for n in range(2048) ]
+        contents_after =  [ str(uuid.uuid4()) for n in range(2048) ]
         path = os.path.join(os.path.abspath(args.dest), "test-s3-pit-restore")
         s3 = boto3.resource('s3')
         self.check_versioning(s3)
@@ -244,7 +248,7 @@ def download_file(obj):
 def get_key(obj):
     if not args.dest:
         return  obj["Key"]
-    return os.path.join(dest, obj["Key"])
+    return os.path.join(args.dest, obj["Key"])
 
 def s3_copy_object(obj):
     copy_source= {
@@ -274,17 +278,16 @@ def do_restore():
     if args.dest_bucket is None:
         if not os.path.exists(dest):
             os.makedirs(dest)
-
         os.chdir(dest)
 
-    # AWS gives us versions chunks of maximum 1000 element, cycling here to obtain more
-    objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix) # cannot pass VersionIdMarker on first call
-    while (True):
-        if not "Versions" in objects:
+    paginator = client.get_paginator('list_object_versions')
+    page_iterator = paginator.paginate(Bucket=args.bucket, Prefix=args.prefix)
+    for page in page_iterator:
+        if not "Versions" in page:
             print("No versions matching criteria, exiting ...", file=sys.stderr)
             sys.exit(1)
-        versions = objects["Versions"]
-        deletemarkers = objects.get("DeleteMarkers", [])
+        versions = page["Versions"]
+        deletemarkers = page.get("DeleteMarkers", [])
         dmarker = {"Key":""}
         for obj in versions:
             if last_obj["Key"] == obj["Key"]:
@@ -327,14 +330,6 @@ def do_restore():
                 except Exception as ex:
                     print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex), file=sys.stderr)
                 del(futures[future])
-
-        if objects["IsTruncated"]:
-            # More objects to be got
-            objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix, \
-                KeyMarker=objects["NextKeyMarker"], VersionIdMarker=objects["NextVersionIdMarker"])
-        else:
-            break
-
 
 if __name__=='__main__':
     signal.signal(signal.SIGINT, signal_handler)

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -37,6 +37,7 @@ args = None
 executor = None
 transfer = None
 futures = {}
+client = None
 
 class TestS3PitRestore(unittest.TestCase):
 
@@ -50,12 +51,27 @@ class TestS3PitRestore(unittest.TestCase):
                 outfile.write(content)
             print(file_path, content)
 
+    def download_restored_file(self, path):
+        base_path = os.path.basename(os.path.normpath(path))
+        if args.dest:
+            base_path = os.path.join(args.dest, base_path)
+
+        s3 = boto3.resource('s3')
+        objects_to_download = s3.meta.client.list_objects(Bucket=args.dest_bucket, Prefix=base_path)
+        with concurrent.futures.ThreadPoolExecutor(args.max_workers) as e:
+            for obj in objects_to_download.get('Contents', []):
+                key_path = os.path.dirname(obj["Key"])
+                if key_path and not os.path.exists(key_path):
+                        os.makedirs(key_path)
+                e.submit(s3.Bucket(args.dest_bucket).download_file(obj["Key"], obj["Key"]))
+
     def check_tree(self, path, contents):
+        if args.dest_bucket is not None:
+            self.download_restored_file(path)
         for i, content in enumerate(contents):
             folder_path = os.path.join(path, "folder%d" % i)
             os.makedirs(folder_path, exist_ok=True)
             file_path = os.path.join(folder_path, "file%d" % i)
-
             in_content=""
             try:
                with open(file_path, 'r') as infile:
@@ -97,14 +113,16 @@ class TestS3PitRestore(unittest.TestCase):
         print("enabled!")
 
     def test_restore(self):
-        contents_before = [ str(uuid.uuid4()) for n in range(2048) ]
-        contents_after =  [ str(uuid.uuid4()) for n in range(2048) ]
+        #AWS gives us versions chunks of maximum 1000 element, cycling here to obtain more
+        contents_before = [ str(uuid.uuid4()) for n in range(999) ]
+        contents_after =  [ str(uuid.uuid4()) for n in range(999) ]
         path = os.path.join(os.path.abspath(args.dest), "test-s3-pit-restore")
         s3 = boto3.resource('s3')
         self.check_versioning(s3)
 
         print("Before ...")
         self.remove_tree(path)
+        time.sleep(1)
         time_before = datetime.now(timezone.utc)
         time.sleep(1)
         self.generate_tree(path, contents_before)
@@ -114,6 +132,7 @@ class TestS3PitRestore(unittest.TestCase):
         print("Upload and owerwriting ...")
         time.sleep(1)
         time_after = datetime.now(timezone.utc)
+        time.sleep(1)
         self.generate_tree(path, contents_after)
         self.upload_directory(s3, path, args.bucket)
         self.remove_tree(path)
@@ -208,14 +227,37 @@ def handled_by_standard(obj):
         return False
     return True
 
+def handled_by_copy(obj):
+    if args.dry_run:
+        print_obj(obj)
+        return True
+    future = executor.submit(s3_copy_object, obj)
+    global futures
+    futures[future] = obj
+    return True
+
 def download_file(obj):
     transfer.download_file(args.bucket, obj["Key"], obj["Key"], extra_args={"VersionId": obj["VersionId"]})
     unixtime = time.mktime(obj["LastModified"].timetuple())
     os.utime(obj["Key"],(unixtime, unixtime))
 
+def get_key(obj):
+    if not args.dest:
+        return  obj["Key"]
+    return os.path.join(dest, obj["Key"])
+
+def s3_copy_object(obj):
+    copy_source= {
+        'Bucket': args.bucket,
+        'Key': obj["Key"],
+        'VersionId': obj["VersionId"]
+    }
+    client.copy_object(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj))
+
 def do_restore():
     pit_start_date = (parse(args.from_timestamp) if args.from_timestamp else datetime.fromtimestamp(0, timezone.utc))
     pit_end_date = (parse(args.timestamp) if args.timestamp else datetime.now(timezone.utc))
+    global client
     client = boto3.client('s3')
     global transfer
     transfer = boto3.s3.transfer.S3Transfer(client)
@@ -228,10 +270,12 @@ def do_restore():
     global executor
     executor = concurrent.futures.ThreadPoolExecutor(args.max_workers)
 
-    if not os.path.exists(dest):
-        os.makedirs(dest)
+    # Only create directories when s3 destination bucket option is missing
+    if args.dest_bucket is None:
+        if not os.path.exists(dest):
+            os.makedirs(dest)
 
-    os.chdir(dest)
+        os.chdir(dest)
 
     # AWS gives us versions chunks of maximum 1000 element, cycling here to obtain more
     objects = client.list_object_versions(Bucket=args.bucket, Prefix=args.prefix) # cannot pass VersionIdMarker on first call
@@ -268,6 +312,10 @@ def do_restore():
             if handled_by_glacier(obj):
                 continue
 
+            if args.dest_bucket is not None:
+                handled_by_copy(obj)
+                continue
+
             if not handled_by_standard(obj):
                 return
 
@@ -293,10 +341,11 @@ if __name__=='__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--bucket', help='s3 bucket to restore from', required=True)
+    parser.add_argument('-B', '--dest-bucket', help='s3 bucket where recovering to', required=False)
     parser.add_argument('-p', '--prefix', help='s3 path to restore from', default="")
     parser.add_argument('-t', '--timestamp', help='final point in time to restore at')
     parser.add_argument('-f', '--from-timestamp', help='starting point in time to restore from')
-    parser.add_argument('-d', '--dest', help='path where recovering to', required=True)
+    parser.add_argument('-d', '--dest', help='path where recovering to on local or on s3', default="")
     parser.add_argument('-e', '--enable-glacier', help='enable recovering from glacier', action='store_true')
     parser.add_argument('-v', '--verbose', help='print verbose informations from s3 objects', action='store_true')
     parser.add_argument('--dry-run', help='execute query without transferring files', action='store_true')
@@ -305,11 +354,24 @@ if __name__=='__main__':
     parser.add_argument('--max-workers', help='max number of concurrent download requests', default=10, type=int)
     args = parser.parse_args()
 
+    if args.dest_bucket is None and not args.dest:
+        parser.error("Either provide destination bucket using (-B ) or provide destination for local restore (-d)")
+        sys.exit(1)
+
     if not args.test:
         do_restore()
     else:
         runner = unittest.TextTestRunner()
-        itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
-        runner.run(itersuite)
+        dest_bucket = args.dest_bucket
+        #To run the test cases for local restore, Later we restore this
+        args.dest_bucket = None
+        if args.dest:
+            itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
+            runner.run(itersuite)
 
+        # Restore back dest_bucket state
+        args.dest_bucket = dest_bucket
+        if args.dest_bucket is not None:
+            itersuite = unittest.TestLoader().loadTestsFromTestCase(TestS3PitRestore)
+            runner.run(itersuite)
     sys.exit(0)

--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -258,6 +258,18 @@ def s3_copy_object(obj):
     }
     client.copy_object(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj))
 
+def handled_by_delete(obj):
+    if args.dry_run:
+        print_obj(obj)
+        return True
+    future = executor.submit(s3_delete_object, obj)
+    global futures
+    futures[future] = obj
+    return True
+
+def s3_delete_object(obj):
+    client.delete_object(Bucket=args.dest_bucket, Key=obj["Key"])
+
 def do_restore():
     pit_start_date = (parse(args.from_timestamp) if args.from_timestamp else datetime.fromtimestamp(0, timezone.utc))
     pit_end_date = (parse(args.timestamp) if args.timestamp else datetime.now(timezone.utc))
@@ -281,6 +293,7 @@ def do_restore():
         os.chdir(dest)
 
     paginator = client.get_paginator('list_object_versions')
+    obj_needs_be_deleted = {}
     page_iterator = paginator.paginate(Bucket=args.bucket, Prefix=args.prefix)
     for page in page_iterator:
         if not "Versions" in page:
@@ -298,6 +311,7 @@ def do_restore():
 
             if version_date > pit_end_date or version_date < pit_start_date:
                 # Object was not updated during pit window
+                obj_needs_be_deleted[obj["Key"]] = obj
                 continue
 
             while deletemarkers and (dmarker["Key"] < obj["Key"] or dmarker["LastModified"] > pit_end_date):
@@ -316,6 +330,7 @@ def do_restore():
                 continue
 
             if args.dest_bucket is not None:
+                obj_needs_be_deleted.pop(obj["Key"], None)
                 handled_by_copy(obj)
                 continue
 
@@ -330,6 +345,18 @@ def do_restore():
                 except Exception as ex:
                     print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex), file=sys.stderr)
                 del(futures[future])
+    # delete objects which came in existence after pit_end_date only if the destination bucket is same as source bucket and restoring to same object key
+    if args.dest_bucket == args.bucket and not args.dest:
+        for key in obj_needs_be_deleted:
+            handled_by_delete(obj_needs_be_deleted[key])
+        for future in concurrent.futures.as_completed(futures):
+            if future in futures:
+                try:
+                    future.result()
+                    print_obj(futures[future])
+                except Exception as ex:
+                    print('"%s" %s %s %s %s "ERROR: %s"' % (obj["LastModified"], obj["VersionId"], obj["Size"], obj["StorageClass"], obj["Key"], ex))
+                del(futures[future])
 
 if __name__=='__main__':
     signal.signal(signal.SIGINT, signal_handler)
@@ -337,10 +364,10 @@ if __name__=='__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--bucket', help='s3 bucket to restore from', required=True)
     parser.add_argument('-B', '--dest-bucket', help='s3 bucket where recovering to', required=False)
+    parser.add_argument('-d', '--dest', help='path where recovering to on local or on s3', default="")
     parser.add_argument('-p', '--prefix', help='s3 path to restore from', default="")
     parser.add_argument('-t', '--timestamp', help='final point in time to restore at')
     parser.add_argument('-f', '--from-timestamp', help='starting point in time to restore from')
-    parser.add_argument('-d', '--dest', help='path where recovering to on local or on s3', default="")
     parser.add_argument('-e', '--enable-glacier', help='enable recovering from glacier', action='store_true')
     parser.add_argument('-v', '--verbose', help='print verbose informations from s3 objects', action='store_true')
     parser.add_argument('--dry-run', help='execute query without transferring files', action='store_true')


### PR DESCRIPTION
This PR is to fix https://github.com/madisoft/s3-pit-restore/issues/22

# Changes:-
* Added option `-B` to restore to s3 bucket
* Made `-d` `required=false` to use it as root directory on s3 buckets as well
* Test cases will run for local and given S3 bucket

# TODO:-
* ~Based on the review update the docs~ :ballot_box_with_check: 
* ~Support more than 1000 objects for testing...~ :ballot_box_with_check: 

@angeloc Can you please review? Thanks!!