### PR TITLE
fix: delete marker handling

### DIFF
--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -215,7 +215,10 @@ def do_restore():
             while deletemarkers and (dmarker["Key"] < obj["Key"] or dmarker["LastModified"] > pit_end_date):
                 dmarker = deletemarkers.pop(0)
 
-            if dmarker["Key"] == obj["Key"] and dmarker["LastModified"] > obj["LastModified"]:
+            if dmarker["Key"] == obj["Key"] and \
+                    dmarker["LastModified"] > obj["LastModified"] and \
+                    dmarker["LastModified"] > pit_start_date and \
+                    dmarker["LastModified"] < pit_end_date:
                 # The most recent operation on this key was a delete
                 last_obj = dmarker
                 continue


### PR DESCRIPTION
thanks for the cool tool!

I ran into an edge case where restore would lose one item, and noticed that it's because `dmarker` is never actually checked to be in the right `pit` date range. Unfortunately, I'm a python newbie and can't take the time to write a test for this, but I have a breaking test for this in node.js: https://github.com/mvayngrib/s3-pit-test

edit: hold up, i seem to have been working with an outdated version of your code! Let me re-check this