### PR TITLE
Fixed restoring big buckets with a lot of delete markers

### DIFF
--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -300,8 +300,8 @@ def do_restore():
     page_iterator = paginator.paginate(Bucket=args.bucket, Prefix=args.prefix)
     for page in page_iterator:
         if not "Versions" in page:
-            print("No versions matching criteria, exiting ...", file=sys.stderr)
-            sys.exit(1)
+            print("No versions matching criteria, continuing...", file=sys.stderr)
+            continue
         versions = page["Versions"]
         deletemarkers = page.get("DeleteMarkers", [])
         dmarker = {"Key":""}


### PR DESCRIPTION
This fixes the loop condition when restoring buckets that have lots of delete markers. 
What happens is - current logic checks if the returned page contains any versions, and if it doesn't - it quits. However, we have a situation when there are thousands of delete markers that are being returned first, followed by some versions - in which case the tool simply quits without looking any further for versions in the following pages. The fix simply allows for scanning through all the pages to make sure all the versions are found 