### PR TITLE
Using copy instead of copy_object

### DIFF
--- a/s3-pit-restore
+++ b/s3-pit-restore
@@ -259,7 +259,7 @@ def s3_copy_object(obj):
         'Key': obj["Key"],
         'VersionId': obj["VersionId"]
     }
-    client.copy_object(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj))
+    client.copy(Bucket=args.dest_bucket, CopySource=copy_source, Key=get_key(obj))
 
 def handled_by_delete(obj):
     if args.dry_run:


### PR DESCRIPTION
This method uses multi-part uploads and can handle files bigger than 5gb.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.copy